### PR TITLE
add Brotli compression to the request

### DIFF
--- a/edgedriver_autoinstaller/utils.py
+++ b/edgedriver_autoinstaller/utils.py
@@ -128,7 +128,7 @@ def get_matched_edgedriver_version(version):
     :param version: the version of edge
     :return: the version of edgedriver
     """
-    doc = requests.get('https://msedgedriver.azureedge.net/').text
+    doc = requests.get('https://msedgedriver.azureedge.net/', headers={'accept-encoding': 'gzip, deflate, br'}).text
     root = elemTree.fromstring(doc)
     for k in root.iter('Name'):
         if k.text.find(get_major_version(version) + '.') == 0:


### PR DESCRIPTION
It seems something has changed in the web server and now it's needed to add Brotli compression ('br') to the accept-encoding headers, in other case the server response this:
`'<?xml version="1.0" encoding="utf-8"?><Error><Code>ResourceNotFound</Code><Message>The specified resource does not exist.\nRequestId:cd55e9b9-901e-00c1-38a1-1266bb000000\nTime:2021-03-06T16:01:06.0504426Z</Message></Error>'`